### PR TITLE
Fix duplicate registration assetBundle

### DIFF
--- a/assets/InfiniteAjaxScrollAsset.php
+++ b/assets/InfiniteAjaxScrollAsset.php
@@ -16,20 +16,9 @@ use yii\web\AssetBundle;
  */
 class InfiniteAjaxScrollAsset extends AssetBundle
 {
-    /**
-     * @var array List of bundle class names that this bundle depends on.
-     */
-    public $depends = [
-        'yii\web\JqueryAsset',
-    ];
+    public $sourcePath = '@vendor/webcreate/jquery-ias/src';
 
-    /**
-     * @inheritdoc
-     */
-    public function init()
-    {
-        $this->sourcePath = '@vendor/webcreate/jquery-ias/src';
-        $this->js = [
+    public $js = [
             'callbacks.js',
             'jquery-ias.js',
             'extension/history.js',
@@ -37,6 +26,14 @@ class InfiniteAjaxScrollAsset extends AssetBundle
             'extension/paging.js',
             'extension/spinner.js',
             'extension/trigger.js'
-        ];
-    }
+    ];
+    
+    /**
+     * @var array List of bundle class names that this bundle depends on.
+     */
+    public $depends = [
+        'yii\web\JqueryAsset',
+    ];
+
+    
 }


### PR DESCRIPTION
If disable asset bundle (for example for ajax requests), if js created through init() this js assets will be forced registered anyway (although it should not)

```php
if (\Yii::$app->request->isAjax) {
            $renderMethod = 'renderPartial';
            \Yii::$app->assetManager->bundles = false;
}
```

Pjax response:
![image](https://user-images.githubusercontent.com/12899080/66488403-85212480-eab6-11e9-9283-33c2aa6f5c81.png)

