### PR TITLE
dynamic loading extension assets

### DIFF
--- a/ScrollPager.php
+++ b/ScrollPager.php
@@ -409,6 +409,7 @@ class ScrollPager extends Widget
                         "Extension {$name} requires " . implode(', ', $depends) . " extensions to be enabled."
                     );
                 }
+                $this->view->registerAssetBundle("kop\y2sp\assets\\{$name}Asset");
 
                 // Register extension
                 $options = Json::encode($options);

--- a/assets/IASHistoryExtensionAsset.php
+++ b/assets/IASHistoryExtensionAsset.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace kop\y2sp\assets;
+
+use yii\web\AssetBundle;
+
+
+/**
+ * Class SpinnerExtensionAsset
+ * @package kop\y2sp\assets
+ */
+class IASHistoryExtensionAsset extends AssetBundle
+{
+
+    public $sourcePath = '@vendor/webcreate/jquery-ias/src';
+
+    public $js = [
+        'extension/history.js'
+    ];
+
+    /**
+     * @var array List of bundle class names that this bundle depends on.
+     */
+    public $depends = [
+        'kop\y2sp\assets\InfiniteAjaxScrollAsset',
+    ];
+
+}

--- a/assets/IASHistoryExtensionAsset.php
+++ b/assets/IASHistoryExtensionAsset.php
@@ -6,7 +6,7 @@ use yii\web\AssetBundle;
 
 
 /**
- * Class SpinnerExtensionAsset
+ * Class IASHistoryExtensionAsset
  * @package kop\y2sp\assets
  */
 class IASHistoryExtensionAsset extends AssetBundle

--- a/assets/IASNoneLeftExtensionAsset.php
+++ b/assets/IASNoneLeftExtensionAsset.php
@@ -6,7 +6,7 @@ use yii\web\AssetBundle;
 
 
 /**
- * Class SpinnerExtensionAsset
+ * Class IASNoneLeftExtensionAsset
  * @package kop\y2sp\assets
  */
 class IASNoneLeftExtensionAsset extends AssetBundle

--- a/assets/IASNoneLeftExtensionAsset.php
+++ b/assets/IASNoneLeftExtensionAsset.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace kop\y2sp\assets;
+
+use yii\web\AssetBundle;
+
+
+/**
+ * Class SpinnerExtensionAsset
+ * @package kop\y2sp\assets
+ */
+class IASNoneLeftExtensionAsset extends AssetBundle
+{
+
+    public $sourcePath = '@vendor/webcreate/jquery-ias/src';
+
+    public $js = [
+        'extension/noneleft.js'
+    ];
+
+    /**
+     * @var array List of bundle class names that this bundle depends on.
+     */
+    public $depends = [
+        'kop\y2sp\assets\InfiniteAjaxScrollAsset',
+    ];
+
+}

--- a/assets/IASPagingExtensionAsset.php
+++ b/assets/IASPagingExtensionAsset.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace kop\y2sp\assets;
+
+use yii\web\AssetBundle;
+
+
+/**
+ * Class SpinnerExtensionAsset
+ * @package kop\y2sp\assets
+ */
+class IASPagingExtensionAsset extends AssetBundle
+{
+
+    public $sourcePath = '@vendor/webcreate/jquery-ias/src';
+
+    public $js = [
+        'extension/paging.js'
+    ];
+
+    /**
+     * @var array List of bundle class names that this bundle depends on.
+     */
+    public $depends = [
+        'kop\y2sp\assets\InfiniteAjaxScrollAsset',
+    ];
+
+}

--- a/assets/IASPagingExtensionAsset.php
+++ b/assets/IASPagingExtensionAsset.php
@@ -6,7 +6,7 @@ use yii\web\AssetBundle;
 
 
 /**
- * Class SpinnerExtensionAsset
+ * Class IASPagingExtensionAsset
  * @package kop\y2sp\assets
  */
 class IASPagingExtensionAsset extends AssetBundle

--- a/assets/IASSpinnerExtensionAsset.php
+++ b/assets/IASSpinnerExtensionAsset.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace kop\y2sp\assets;
+
+use yii\web\AssetBundle;
+
+
+/**
+ * Class SpinnerExtensionAsset
+ * @package kop\y2sp\assets
+ */
+class IASSpinnerExtensionAsset extends AssetBundle
+{
+
+    public $sourcePath = '@vendor/webcreate/jquery-ias/src';
+
+    public $js = [
+        'extension/spinner.js'
+    ];
+
+    /**
+     * @var array List of bundle class names that this bundle depends on.
+     */
+    public $depends = [
+        'kop\y2sp\assets\InfiniteAjaxScrollAsset',
+    ];
+
+}

--- a/assets/IASSpinnerExtensionAsset.php
+++ b/assets/IASSpinnerExtensionAsset.php
@@ -6,7 +6,7 @@ use yii\web\AssetBundle;
 
 
 /**
- * Class SpinnerExtensionAsset
+ * Class IASSpinnerExtensionAsset
  * @package kop\y2sp\assets
  */
 class IASSpinnerExtensionAsset extends AssetBundle

--- a/assets/IASTriggerExtensionAsset.php
+++ b/assets/IASTriggerExtensionAsset.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace kop\y2sp\assets;
+
+use yii\web\AssetBundle;
+
+
+/**
+ * Class SpinnerExtensionAsset
+ * @package kop\y2sp\assets
+ */
+class IASTriggerExtensionAsset extends AssetBundle
+{
+
+    public $sourcePath = '@vendor/webcreate/jquery-ias/src';
+
+    public $js = [
+        'extension/trigger.js'
+    ];
+
+    /**
+     * @var array List of bundle class names that this bundle depends on.
+     */
+    public $depends = [
+        'kop\y2sp\assets\InfiniteAjaxScrollAsset',
+    ];
+
+}

--- a/assets/IASTriggerExtensionAsset.php
+++ b/assets/IASTriggerExtensionAsset.php
@@ -6,7 +6,7 @@ use yii\web\AssetBundle;
 
 
 /**
- * Class SpinnerExtensionAsset
+ * Class IASTriggerExtensionAsset
  * @package kop\y2sp\assets
  */
 class IASTriggerExtensionAsset extends AssetBundle

--- a/assets/InfiniteAjaxScrollAsset.php
+++ b/assets/InfiniteAjaxScrollAsset.php
@@ -16,24 +16,19 @@ use yii\web\AssetBundle;
  */
 class InfiniteAjaxScrollAsset extends AssetBundle
 {
+
     public $sourcePath = '@vendor/webcreate/jquery-ias/src';
 
     public $js = [
-            'callbacks.js',
-            'jquery-ias.js',
-            'extension/history.js',
-            'extension/noneleft.js',
-            'extension/paging.js',
-            'extension/spinner.js',
-            'extension/trigger.js'
+        'callbacks.js',
+        'jquery-ias.js'
     ];
-    
+
     /**
      * @var array List of bundle class names that this bundle depends on.
      */
     public $depends = [
         'yii\web\JqueryAsset',
     ];
-
     
 }


### PR DESCRIPTION
Probably we shouldn't register unnecessary assets if use not all extensions

```php
'enabledExtensions' => [
                    ScrollPager::EXTENSION_SPINNER
],
```